### PR TITLE
fix: oauth redirect endpoint

### DIFF
--- a/api/src/main/java/com/example/muse/global/security/config/SecurityConfig.java
+++ b/api/src/main/java/com/example/muse/global/security/config/SecurityConfig.java
@@ -55,6 +55,9 @@ public class SecurityConfig {
                         .authorizationEndpoint(endpoint -> endpoint
                                 .baseUri("/api/oauth2/authorization")
                         )
+                        .redirectionEndpoint(endpoint -> endpoint
+                                .baseUri("/api/login/oauth2/code/{registrationId}")
+                        )
                         .successHandler(oAuth2SuccessHandler)
                         .failureHandler(oAuth2FailureHandler)
                         .userInfoEndpoint(userInfo -> userInfo

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -53,10 +53,12 @@ spring.security.oauth2.client.registration.kakao.client-authentication-method=cl
 spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID}
 spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET}
 spring.security.oauth2.client.registration.google.scope=${GOOGLE_SCOPE}
+spring.security.oauth2.client.registration.google.redirect-uri=${GOOGLE_REDIRECT_URI}
 
 spring.security.oauth2.client.registration.naver.client-id=${NAVER_CLIENT_ID}
 spring.security.oauth2.client.registration.naver.client-secret=${NAVER_CLIENT_SECRET}
 spring.security.oauth2.client.registration.naver.scope=${NAVER_SCOPE}
+spring.security.oauth2.client.registration.naver.redirect-uri=${NAVER_REDIRECT_URI}
 
 
 ##### swagger


### PR DESCRIPTION
## 📝 변경 사항

- SecurityConfig에서 redirectEndpoint의 baseuri 수정
- application.properties의 provier별 redirect_endpoint 설정

## 📌 참고 사항

- .env 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - OAuth2 로그인 시 인증 후 리디렉션되는 경로가 "/api/login/oauth2/code/{registrationId}"로 설정되었습니다.
- **문서화**
  - Google과 Naver OAuth2 클라이언트 등록에 대한 redirect-uri 설정이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->