### PR TITLE
fix: image loic

### DIFF
--- a/api/src/main/java/com/example/muse/domain/image/dto/ImageDto.java
+++ b/api/src/main/java/com/example/muse/domain/image/dto/ImageDto.java
@@ -14,6 +14,10 @@ public class ImageDto {
 
     public static ImageDto from(Image image) {
 
+        if (image == null) {
+            return new ImageDto(null, null);
+        }
+
         return new ImageDto(
                 image.getImageUrl(),
                 image.getOriginalFileName()

--- a/api/src/main/java/com/example/muse/domain/review/ReviewService.java
+++ b/api/src/main/java/com/example/muse/domain/review/ReviewService.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -104,9 +104,9 @@ public class ReviewService {
             throw new IllegalArgumentException("작성자만 제거할 수 있습니다.");
         }
 
-        Image image = review.getImage();
+        Optional.ofNullable(review.getImage())
+                .ifPresent(imageService::deleteImage);
 
-        imageService.deleteImage(image);
         reviewRepository.delete(review);
     }
 
@@ -154,7 +154,7 @@ public class ReviewService {
     public GetReviewDetailResponseDto getReview(Long bookId, Long reviewId, Member member) {
 
         Review review = reviewRepository.findReviewWithBookById(reviewId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 리뷰입니다."));
-        if (!Objects.equals(review.getBook().getId(), bookId)) {
+        if (review.getBook().getId() != bookId) {
             throw new IllegalArgumentException("존재하지 않는 도서입니다.");
         }
         ReviewDetailDto reviewDto = ReviewDetailDto.from(review, member);

--- a/api/src/main/java/com/example/muse/global/security/handler/JwtAuthenticationEntryPoint.java
+++ b/api/src/main/java/com/example/muse/global/security/handler/JwtAuthenticationEntryPoint.java
@@ -20,7 +20,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 
-        ApiResponse<Void> ErrorResponse = ApiResponse.error("로그인이 필요합니다.", "UNAUTHORIZED");
+        ApiResponse<Void> ErrorResponse = ApiResponse.error("인증 실패", "UNAUTHORIZED");
         response.getWriter().write(objectMapper.writeValueAsString(ErrorResponse));
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 이미지 정보가 없는 경우에도 예외 없이 정상적으로 처리되도록 개선되었습니다.
  - 리뷰 삭제 시 이미지가 존재할 때만 안전하게 삭제하도록 동작이 변경되었습니다.
  - 리뷰 조회 시 책 ID 비교 방식이 보다 안전하게 개선되었습니다.

- **스타일**
  - 인증 실패 시 반환되는 오류 메시지가 "로그인이 필요합니다."에서 "인증 실패"로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->