### PR TITLE
fix: image lifecycle

### DIFF
--- a/api/src/main/java/com/example/muse/domain/auth/AuthService.java
+++ b/api/src/main/java/com/example/muse/domain/auth/AuthService.java
@@ -144,9 +144,9 @@ public class AuthService {
     @Transactional(readOnly = true)
     public LoginResponseDto getLoginWithData(Member member) {
 
-        Image lastProfileImage = imageRepository.findProfileImageByMemberId(member.getId())
+        Image profileImage = imageRepository.findProfileImageByMemberId(member.getId())
                 .orElse(null);
 
-        return LoginResponseDto.from(member, lastProfileImage);
+        return LoginResponseDto.from(member, profileImage);
     }
 }

--- a/api/src/main/java/com/example/muse/domain/book/Book.java
+++ b/api/src/main/java/com/example/muse/domain/book/Book.java
@@ -4,7 +4,6 @@ import com.example.muse.domain.like.Likes;
 import com.example.muse.domain.review.Review;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.BatchSize;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -31,11 +30,9 @@ public class Book {
     @Column(name = "description", columnDefinition = "TEXT")
     private String description;
 
-    @BatchSize(size = 10)
     @OneToMany(mappedBy = "book", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Review> reviews = new ArrayList<>();
 
-    @BatchSize(size = 10)
     @OneToMany(mappedBy = "book", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Likes> likes = new ArrayList<>();
 

--- a/api/src/main/java/com/example/muse/domain/book/Book.java
+++ b/api/src/main/java/com/example/muse/domain/book/Book.java
@@ -7,7 +7,9 @@ import lombok.*;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -34,7 +36,7 @@ public class Book {
     private List<Review> reviews = new ArrayList<>();
 
     @OneToMany(mappedBy = "book", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
-    private List<Likes> likes = new ArrayList<>();
+    private Set<Likes> likes = new HashSet<>();
 
     @PrePersist
     @PreUpdate

--- a/api/src/main/java/com/example/muse/domain/book/BookService.java
+++ b/api/src/main/java/com/example/muse/domain/book/BookService.java
@@ -102,7 +102,7 @@ public class BookService {
                 ? bookRepository.findLikedBooksOrderByLikesDesc(member.getId(), pageable)
                 : bookRepository.findLikedBooksOrderByDateDesc(member.getId(), pageable);
 
-        Page<BookDto> bookDtoPage = bookPage.map(book -> BookDto.from(book, member));
+        Page<BookDto> bookDtoPage = bookPage.map(book -> BookDto.from(book, member, true));
 
         return GetBooksResponseDto.from(bookDtoPage);
     }

--- a/api/src/main/java/com/example/muse/domain/book/dto/BookDto.java
+++ b/api/src/main/java/com/example/muse/domain/book/dto/BookDto.java
@@ -1,6 +1,7 @@
 package com.example.muse.domain.book.dto;
 
 import com.example.muse.domain.book.Book;
+import com.example.muse.domain.like.Likes;
 import com.example.muse.domain.member.Member;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -25,9 +26,29 @@ public class BookDto {
     private String isbn;
 
     public static BookDto from(Book book, Member member) {
+
+        Likes likes = Likes.builder()
+                .member(member)
+                .book(book)
+                .build();
+
         boolean isLiked = member != null &&
-                book.getLikes().stream()
-                        .anyMatch(like -> like.getMember().getId().equals(member.getId()));
+                book.getLikes().contains(likes);
+
+        return BookDto.builder()
+                .id(book.getId())
+                .imageUrl(book.getImageUrl())
+                .title(book.getTitle())
+                .author(book.getAuthor().replace("^", " "))
+                .publisher(book.getPublisher())
+                .likeCount(book.getLikes().size())
+                .isLike(isLiked)
+                .publishedDate(book.getPublishedDate())
+                .isbn(book.getIsbn())
+                .build();
+    }
+
+    public static BookDto from(Book book, Member member, boolean isLiked) {
 
         return BookDto.builder()
                 .id(book.getId())

--- a/api/src/main/java/com/example/muse/domain/image/Image.java
+++ b/api/src/main/java/com/example/muse/domain/image/Image.java
@@ -8,8 +8,6 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter
@@ -44,7 +42,7 @@ public class Image {
     @CreatedDate
     private LocalDateTime createdAt;
 
-    @OneToMany(mappedBy = "image", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, fetch = FetchType.LAZY)
-    private List<Review> reviews = new ArrayList<>();
+    @OneToOne(mappedBy = "image", fetch = FetchType.LAZY)
+    private Review review;
 }
 

--- a/api/src/main/java/com/example/muse/domain/image/Image.java
+++ b/api/src/main/java/com/example/muse/domain/image/Image.java
@@ -42,7 +42,8 @@ public class Image {
     @CreatedDate
     private LocalDateTime createdAt;
 
-    @OneToOne(mappedBy = "image", fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id")
     private Review review;
 }
 

--- a/api/src/main/java/com/example/muse/domain/image/ImageRepository.java
+++ b/api/src/main/java/com/example/muse/domain/image/ImageRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -11,4 +12,6 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
 
     @Query("SELECT i FROM Image i WHERE i.member.id = :memberId AND i.imageType = 'PROFILE'")
     Optional<Image> findProfileImageByMemberId(@Param("memberId") UUID memberId);
+
+    List<Image> findAllByMemberIdInAndImageType(List<UUID> memberIds, ImageType imageType);
 }

--- a/api/src/main/java/com/example/muse/domain/image/ImageRepository.java
+++ b/api/src/main/java/com/example/muse/domain/image/ImageRepository.java
@@ -1,5 +1,6 @@
 package com.example.muse.domain.image;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,8 +11,10 @@ import java.util.UUID;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
 
+    @EntityGraph(attributePaths = {"member"})
     @Query("SELECT i FROM Image i WHERE i.member.id = :memberId AND i.imageType = 'PROFILE'")
     Optional<Image> findProfileImageByMemberId(@Param("memberId") UUID memberId);
 
+    @EntityGraph(attributePaths = {"member"})
     List<Image> findAllByMemberIdInAndImageType(List<UUID> memberIds, ImageType imageType);
 }

--- a/api/src/main/java/com/example/muse/domain/image/ImageService.java
+++ b/api/src/main/java/com/example/muse/domain/image/ImageService.java
@@ -60,9 +60,10 @@ public class ImageService {
     public void deleteImage(Image image) {
 
         try {
+            Member member = image.getMember();
             s3Service.deleteFile(image.getS3Key());
             imageRepository.delete(image);
-            
+            member.getImages().remove(image);
         } catch (Exception e) {
             throw new CustomS3Exception();
         }

--- a/api/src/main/java/com/example/muse/domain/image/ImageService.java
+++ b/api/src/main/java/com/example/muse/domain/image/ImageService.java
@@ -82,9 +82,4 @@ public class ImageService {
         return ALLOWED_IMAGE_TYPES.contains(contentType)
                 && fileName.toLowerCase().matches(IMAGE_FILE_NAME_PATTERN);
     }
-
-    public Image getImageById(long l) {
-
-        return imageRepository.findById(l).orElse(null);
-    }
 }

--- a/api/src/main/java/com/example/muse/domain/like/Likes.java
+++ b/api/src/main/java/com/example/muse/domain/like/Likes.java
@@ -14,7 +14,6 @@ import java.util.UUID;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Table(
         uniqueConstraints = {
                 @UniqueConstraint(columnNames = {"member_id", "book_id"}),

--- a/api/src/main/java/com/example/muse/domain/like/Likes.java
+++ b/api/src/main/java/com/example/muse/domain/like/Likes.java
@@ -4,16 +4,17 @@ import com.example.muse.domain.book.Book;
 import com.example.muse.domain.member.Member;
 import com.example.muse.domain.review.Review;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+
+import java.util.Objects;
+import java.util.UUID;
 
 @Entity
 @Getter
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Table(
         uniqueConstraints = {
                 @UniqueConstraint(columnNames = {"member_id", "book_id"}),
@@ -35,4 +36,33 @@ public class Likes {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "review_id")
     private Review review;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Likes)) return false;
+        Likes other = (Likes) o;
+        UUID memberId = member != null ? member.getId() : null;
+        UUID otherMemberId = other.member != null ? other.member.getId() : null;
+        if (!Objects.equals(memberId, otherMemberId)) return false;
+
+        if (this.review != null || other.review != null) {
+            Long reviewId = this.review != null ? this.review.getId() : null;
+            Long otherReviewId = other.review != null ? other.review.getId() : null;
+            return Objects.equals(reviewId, otherReviewId);
+        }
+
+        Long bookId = book != null ? book.getId() : null;
+        Long otherBookId = other.book != null ? other.book.getId() : null;
+        return Objects.equals(bookId, otherBookId);
+    }
+
+    @Override
+    public int hashCode() {
+        UUID memberId = member != null ? member.getId() : null;
+        if (review != null) {
+            return Objects.hash(memberId, review.getId());
+        }
+        return Objects.hash(memberId, book != null ? book.getId() : null);
+    }
 }

--- a/api/src/main/java/com/example/muse/domain/member/Member.java
+++ b/api/src/main/java/com/example/muse/domain/member/Member.java
@@ -1,7 +1,6 @@
 package com.example.muse.domain.member;
 
 import com.example.muse.domain.image.Image;
-import com.example.muse.domain.image.ImageType;
 import com.example.muse.domain.like.Likes;
 import com.example.muse.domain.review.Review;
 import jakarta.persistence.*;
@@ -29,8 +28,6 @@ public class Member implements OAuth2User {
     @Column(nullable = false)
     private String nickname;
 
-    @Transient
-    private Image profileImage;
 
     @OneToMany(mappedBy = "member", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, fetch = FetchType.LAZY)
     private List<Likes> likes = new ArrayList<>();
@@ -63,13 +60,6 @@ public class Member implements OAuth2User {
         return nickname;
     }
 
-    @PostLoad
-    private void initializeProfileImage() {
-        this.profileImage = images.stream()
-                .filter(image -> image.getImageType() == ImageType.PROFILE)
-                .findAny()
-                .orElse(null);
-    }
 
     public void addAuthenticationProviders(AuthenticationProvider authenticationProvider) {
         authenticationProviders.add(authenticationProvider);
@@ -82,14 +72,8 @@ public class Member implements OAuth2User {
         }
         if (image != null) {
             this.images.add(image);
-            this.profileImage = image;
         }
 
         return this;
-    }
-
-    public String getProfileImageUrl() {
-
-        return profileImage == null ? null : profileImage.getImageUrl();
     }
 }

--- a/api/src/main/java/com/example/muse/domain/member/Member.java
+++ b/api/src/main/java/com/example/muse/domain/member/Member.java
@@ -28,9 +28,8 @@ public class Member implements OAuth2User {
     @Column(nullable = false)
     private String nickname;
 
-
     @OneToMany(mappedBy = "member", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, fetch = FetchType.LAZY)
-    private List<Likes> likes = new ArrayList<>();
+    private Set<Likes> likes = new HashSet<>();
 
     @OneToMany(mappedBy = "member", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, fetch = FetchType.LAZY)
     private List<Image> images = new ArrayList<>();

--- a/api/src/main/java/com/example/muse/domain/member/MemberRepository.java
+++ b/api/src/main/java/com/example/muse/domain/member/MemberRepository.java
@@ -2,15 +2,15 @@ package com.example.muse.domain.member;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface MemberRepository extends JpaRepository<Member, UUID> {
+
     Optional<Member> findByAuthenticationProvidersProviderAndAuthenticationProvidersProviderKey(
             Provider provider,
             String providerKey
     );
-
+    
     Optional<Member> findById(UUID memberId);
 }

--- a/api/src/main/java/com/example/muse/domain/member/MemberService.java
+++ b/api/src/main/java/com/example/muse/domain/member/MemberService.java
@@ -6,6 +6,7 @@ import com.example.muse.domain.image.ImageService;
 import com.example.muse.domain.image.ImageType;
 import com.example.muse.domain.member.dto.GetProfileResponseDto;
 import com.example.muse.domain.member.dto.MemberProfileDto;
+import com.example.muse.domain.review.ReviewRepository;
 import com.example.muse.global.common.exception.CustomNotFoundException;
 import com.example.muse.global.common.exception.CustomUnauthorizedException;
 import lombok.RequiredArgsConstructor;
@@ -24,16 +25,19 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final ImageRepository imageRepository;
     private final ImageService imageService;
+    private final ReviewRepository reviewRepository;
 
     public GetProfileResponseDto getProfile(UUID memberId) {
 
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(CustomNotFoundException::new);
 
-        Image profileImage = imageRepository.findProfileImageByMemberId(memberId)
+        String profileImageUrl = imageRepository.findProfileImageByMemberId(memberId)
+                .map(Image::getImageUrl)
                 .orElse(null);
+        long reviewCount = reviewRepository.countByMemberId(memberId);
 
-        return GetProfileResponseDto.from(member, profileImage);
+        return GetProfileResponseDto.from(member, profileImageUrl, reviewCount);
     }
 
     @Transactional

--- a/api/src/main/java/com/example/muse/domain/member/MemberService.java
+++ b/api/src/main/java/com/example/muse/domain/member/MemberService.java
@@ -56,6 +56,6 @@ public class MemberService {
         }
 
         member.update(nickname, image);
-        return MemberProfileDto.from(member);
+        return MemberProfileDto.from(member, image.getImageUrl());
     }
 }

--- a/api/src/main/java/com/example/muse/domain/member/dto/GetProfileResponseDto.java
+++ b/api/src/main/java/com/example/muse/domain/member/dto/GetProfileResponseDto.java
@@ -1,13 +1,11 @@
 package com.example.muse.domain.member.dto;
 
-import com.example.muse.domain.image.Image;
 import com.example.muse.domain.member.Member;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.Optional;
 import java.util.UUID;
 
 @Getter
@@ -20,13 +18,7 @@ public class GetProfileResponseDto {
     private String profileImageUrl;
     private long reviewCount;
 
-    public static GetProfileResponseDto from(Member member, Image profileImage) {
-
-        String profileImageUrl = Optional.ofNullable(profileImage)
-                .map(Image::getImageUrl)
-                .orElse(null);
-
-        long reviewCount = member.getReviews().size();
+    public static GetProfileResponseDto from(Member member, String profileImageUrl, long reviewCount) {
 
         return GetProfileResponseDto.builder()
                 .memberId(member.getId())

--- a/api/src/main/java/com/example/muse/domain/member/dto/MemberProfileDto.java
+++ b/api/src/main/java/com/example/muse/domain/member/dto/MemberProfileDto.java
@@ -17,12 +17,12 @@ public class MemberProfileDto {
     private String nickname;
     private String profileImageUrl;
 
-    public static MemberProfileDto from(Member member) {
+    public static MemberProfileDto from(Member member, String profileImageUrl) {
 
         return MemberProfileDto.builder()
                 .memberId(member.getId())
                 .nickname(member.getNickname())
-                .profileImageUrl(member.getProfileImageUrl())
+                .profileImageUrl(profileImageUrl)
                 .build();
     }
 }

--- a/api/src/main/java/com/example/muse/domain/review/Review.java
+++ b/api/src/main/java/com/example/muse/domain/review/Review.java
@@ -25,7 +25,7 @@ public class Review extends BaseTimeEntity {
     private Long id;
     private String content;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "image_id")
     private Image image;
 

--- a/api/src/main/java/com/example/muse/domain/review/Review.java
+++ b/api/src/main/java/com/example/muse/domain/review/Review.java
@@ -8,7 +8,6 @@ import com.example.muse.domain.review.dto.UpdateReviewRequestDto;
 import com.example.muse.global.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.BatchSize;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,7 +24,7 @@ public class Review extends BaseTimeEntity {
     private Long id;
     private String content;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     @JoinColumn(name = "image_id")
     private Image image;
 
@@ -37,7 +36,7 @@ public class Review extends BaseTimeEntity {
     @JoinColumn(name = "book_id", nullable = false)
     private Book book;
 
-    @BatchSize(size = 10)
+
     @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Likes> likes = new ArrayList<>();
 

--- a/api/src/main/java/com/example/muse/domain/review/Review.java
+++ b/api/src/main/java/com/example/muse/domain/review/Review.java
@@ -24,8 +24,7 @@ public class Review extends BaseTimeEntity {
     private Long id;
     private String content;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE})
-    @JoinColumn(name = "image_id")
+    @OneToOne(mappedBy = "review", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private Image image;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/api/src/main/java/com/example/muse/domain/review/Review.java
+++ b/api/src/main/java/com/example/muse/domain/review/Review.java
@@ -8,9 +8,11 @@ import com.example.muse.domain.review.dto.UpdateReviewRequestDto;
 import com.example.muse.global.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -25,19 +27,21 @@ public class Review extends BaseTimeEntity {
     private String content;
 
     @OneToOne(mappedBy = "review", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @Fetch(FetchMode.JOIN)
     private Image image;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
+    @Fetch(FetchMode.JOIN)
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "book_id", nullable = false)
+    @Fetch(FetchMode.JOIN)
     private Book book;
 
-
     @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
-    private List<Likes> likes = new ArrayList<>();
+    private Set<Likes> likes = new HashSet<>();
 
     public Review update(UpdateReviewRequestDto requestDto, Image image) {
 

--- a/api/src/main/java/com/example/muse/domain/review/ReviewRepository.java
+++ b/api/src/main/java/com/example/muse/domain/review/ReviewRepository.java
@@ -88,4 +88,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             ORDER BY r.createdAt DESC
             """)
     Page<Review> findByMemberIdOrderByDateDesc(Pageable pageable, @Param("memberId") UUID memberId);
+
+    long countByMemberId(UUID memberId);
 }

--- a/api/src/main/java/com/example/muse/domain/review/ReviewRepository.java
+++ b/api/src/main/java/com/example/muse/domain/review/ReviewRepository.java
@@ -46,8 +46,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
               JOIN r.likes lm
               ON lm.member.id = :id
               LEFT JOIN r.likes la
-              GROUP BY r.id
-              ORDER BY COUNT(la) DESC
+              ORDER BY SIZE(r.likes) DESC
             """)
     Page<Review> findLikedReviewsOrderByLikesDesc(@Param("id") UUID id, Pageable pageable);
 

--- a/api/src/main/java/com/example/muse/domain/review/ReviewRepository.java
+++ b/api/src/main/java/com/example/muse/domain/review/ReviewRepository.java
@@ -12,14 +12,14 @@ import java.util.UUID;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
-    @EntityGraph(attributePaths = {"book", "member", "image", "likes"})
+    @EntityGraph(attributePaths = {"book", "member", "image"})
     @Query("""
             SELECT r FROM Review r
             ORDER BY SIZE(r.likes) DESC
             """)
     Page<Review> findMainReviews(Pageable pageable);
 
-    @EntityGraph(attributePaths = {"book", "member", "image", "likes"})
+    @EntityGraph(attributePaths = {"book", "member", "image"})
     @Query("""
             SELECT r
             FROM Review r
@@ -29,7 +29,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             """)
     Page<Review> findByBookIdOrderByLikesDesc(Pageable pageable, @Param("bookId") Long bookId);
 
-    @EntityGraph(attributePaths = {"book", "member", "image", "likes"})
+    @EntityGraph(attributePaths = {"book", "member", "image"})
     @Query("""
             SELECT r
             FROM Review r
@@ -39,7 +39,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             """)
     Page<Review> findByBookIdOrderByDateDesc(Pageable pageable, @Param("bookId") Long bookId);
 
-    @EntityGraph(attributePaths = {"book", "member", "image", "likes"})
+    @EntityGraph(attributePaths = {"book", "member", "image"})
     @Query("""
               SELECT r
               FROM Review r
@@ -50,7 +50,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             """)
     Page<Review> findLikedReviewsOrderByLikesDesc(@Param("id") UUID id, Pageable pageable);
 
-    @EntityGraph(attributePaths = {"book", "member", "image", "likes"})
+    @EntityGraph(attributePaths = {"book", "member", "image"})
     @Query("""
             SELECT r
             FROM Review r
@@ -60,7 +60,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             """)
     Page<Review> findLikedReviewsByMemberIdOrderByCreatedAtDesc(@Param("id") UUID id, Pageable pageable);
 
-    @EntityGraph(attributePaths = {"book", "member", "image", "likes"})
+    @EntityGraph(attributePaths = {"book", "member", "image"})
     @Query("""
             SELECT r
             FROM Review r
@@ -68,7 +68,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             """)
     Optional<Review> findReviewWithBookById(@Param("reviewId") Long reviewId);
 
-    @EntityGraph(attributePaths = {"book", "member", "image", "likes"})
+    @EntityGraph(attributePaths = {"book", "member", "image"})
     @Query("""
             SELECT r
             FROM Review r
@@ -79,7 +79,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             """)
     Page<Review> findByMemberIdOrderByLikesDesc(Pageable pageable, @Param("memberId") UUID memberId);
 
-    @EntityGraph(attributePaths = {"book", "member", "image", "likes"})
+    @EntityGraph(attributePaths = {"book", "member", "image"})
     @Query("""
             SELECT r
             FROM Review r

--- a/api/src/main/java/com/example/muse/domain/review/ReviewRepository.java
+++ b/api/src/main/java/com/example/muse/domain/review/ReviewRepository.java
@@ -2,64 +2,34 @@ package com.example.muse.domain.review;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
+    @EntityGraph(attributePaths = {"book", "member", "image", "likes"})
     @Query("""
             SELECT r FROM Review r
-            LEFT JOIN r.likes l
-            GROUP BY r
-            ORDER BY COUNT(l) DESC
+            ORDER BY SIZE(r.likes) DESC
             """)
     Page<Review> findMainReviews(Pageable pageable);
 
-    // TODO
-    Page<Review> findByMemberId(Pageable pageable, UUID memberId);
-
-    @Query(value = """
-            SELECT r.*
-            FROM review r
-            LEFT JOIN likes l ON r.id = l.review_id
-            WHERE r.member_id = :memberId
-            GROUP BY r.id
-            ORDER BY COUNT(l.id) DESC
-            LIMIT :limit OFFSET :offset
-            """,
-            nativeQuery = true
-    )
-    List<Review> findReviewsByMemberIdOrderByLikesDesc(
-            @Param("memberId") UUID memberId,
-            @Param("limit") int limit,
-            @Param("offset") long offset
-    );
-
-    @Query(value = """
-            SELECT COUNT(DISTINCT r.id)
-            FROM review r
-            WHERE r.member_id = :memberId
-            """,
-            nativeQuery = true
-    )
-    long countReviewsByMemberId(@Param("memberId") UUID memberId);
-
+    @EntityGraph(attributePaths = {"book", "member", "image", "likes"})
     @Query("""
             SELECT r
             FROM Review r
             JOIN r.book b
-            LEFT JOIN r.likes l
             WHERE r.book.id = :bookId
-            GROUP BY r
-            ORDER BY COUNT(l) DESC
+            ORDER BY SIZE(r.likes) DESC
             """)
     Page<Review> findByBookIdOrderByLikesDesc(Pageable pageable, @Param("bookId") Long bookId);
 
+    @EntityGraph(attributePaths = {"book", "member", "image", "likes"})
     @Query("""
             SELECT r
             FROM Review r
@@ -69,6 +39,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             """)
     Page<Review> findByBookIdOrderByDateDesc(Pageable pageable, @Param("bookId") Long bookId);
 
+    @EntityGraph(attributePaths = {"book", "member", "image", "likes"})
     @Query("""
               SELECT r
               FROM Review r
@@ -80,6 +51,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             """)
     Page<Review> findLikedReviewsOrderByLikesDesc(@Param("id") UUID id, Pageable pageable);
 
+    @EntityGraph(attributePaths = {"book", "member", "image", "likes"})
     @Query("""
             SELECT r
             FROM Review r
@@ -89,14 +61,15 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             """)
     Page<Review> findLikedReviewsByMemberIdOrderByCreatedAtDesc(@Param("id") UUID id, Pageable pageable);
 
+    @EntityGraph(attributePaths = {"book", "member", "image", "likes"})
     @Query("""
             SELECT r
             FROM Review r
-            JOIN FETCH r.book b
             WHERE r.id = :reviewId
             """)
     Optional<Review> findReviewWithBookById(@Param("reviewId") Long reviewId);
 
+    @EntityGraph(attributePaths = {"book", "member", "image", "likes"})
     @Query("""
             SELECT r
             FROM Review r
@@ -107,6 +80,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             """)
     Page<Review> findByMemberIdOrderByLikesDesc(Pageable pageable, @Param("memberId") UUID memberId);
 
+    @EntityGraph(attributePaths = {"book", "member", "image", "likes"})
     @Query("""
             SELECT r
             FROM Review r

--- a/api/src/main/java/com/example/muse/domain/review/ReviewService.java
+++ b/api/src/main/java/com/example/muse/domain/review/ReviewService.java
@@ -14,6 +14,7 @@ import com.example.muse.global.common.exception.CustomBadRequestException;
 import com.example.muse.global.common.exception.CustomNotFoundException;
 import com.example.muse.global.common.exception.CustomUnauthorizedException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -28,6 +29,7 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class ReviewService {
     public static final Set<String> ALLOWED_SORTS = Set.of("createdAt", "likes");
     private final ReviewRepository reviewRepository;
@@ -53,14 +55,16 @@ public class ReviewService {
 
 
     public GetReviewCardsResponseDto getMainReviews(Pageable pageable, Member member) {
+        log.warn("메서드 호출");
         pageable = setDefaultSort(pageable);
+        log.warn("reviews 조회 시작");
         Page<Review> reviews = reviewRepository.findMainReviews(pageable);
-
+        log.warn("memberIds 꺼내기 시작");
         List<UUID> memberIds = reviews.getContent().stream()
                 .map(review -> review.getMember().getId())
                 .distinct()
                 .toList();
-
+        log.warn("profileImageMap 만들기 시작");
         Map<UUID, String> profileImageMap = imageRepository
                 .findAllByMemberIdInAndImageType(memberIds, ImageType.PROFILE)
                 .stream()
@@ -68,7 +72,7 @@ public class ReviewService {
                         image -> image.getMember().getId(),
                         Image::getImageUrl
                 ));
-
+        log.warn("응답 시작");
         return GetReviewCardsResponseDto.from(reviews, member, profileImageMap);
     }
 

--- a/api/src/main/java/com/example/muse/domain/review/ReviewService.java
+++ b/api/src/main/java/com/example/muse/domain/review/ReviewService.java
@@ -108,7 +108,7 @@ public class ReviewService {
         }
 
         Optional.ofNullable(review.getImage())
-                .ifPresent(imageService::deleteImage);
+                .ifPresent(imageService::deleteImage); //TODO: 이벤트 기반으로 변경
 
         reviewRepository.delete(review);
     }

--- a/api/src/main/java/com/example/muse/domain/review/dto/GetLikedReviewsResponseDto.java
+++ b/api/src/main/java/com/example/muse/domain/review/dto/GetLikedReviewsResponseDto.java
@@ -24,7 +24,7 @@ public class GetLikedReviewsResponseDto {
     private boolean hasPrevious;
     private long totalElements;
 
-    public static GetLikedReviewsResponseDto from(Page<Review> reviews, Member member) {
+    public static GetLikedReviewsResponseDto from(Page<Review> reviews, Member member, String profileImageUrl) {
 
         List<ReviewCardResponseDto> reviewCardResponseDtoList
                 = reviews.getContent().stream()
@@ -32,7 +32,7 @@ public class GetLikedReviewsResponseDto {
                         review -> ReviewCardResponseDto.from(
                                 BookDto.from(review.getBook(), member),
                                 ReviewDto.from(review, member),
-                                MemberProfileDto.from(review.getMember())
+                                MemberProfileDto.from(review.getMember(), profileImageUrl)
                         )
                 ).toList();
 

--- a/api/src/main/java/com/example/muse/domain/review/dto/GetLikedReviewsResponseDto.java
+++ b/api/src/main/java/com/example/muse/domain/review/dto/GetLikedReviewsResponseDto.java
@@ -31,7 +31,7 @@ public class GetLikedReviewsResponseDto {
                 .map(
                         review -> ReviewCardResponseDto.from(
                                 BookDto.from(review.getBook(), member),
-                                ReviewDto.from(review, member),
+                                ReviewDto.from(review, member, true),
                                 MemberProfileDto.from(review.getMember(), profileImageUrl)
                         )
                 ).toList();

--- a/api/src/main/java/com/example/muse/domain/review/dto/GetReviewCardsResponseDto.java
+++ b/api/src/main/java/com/example/muse/domain/review/dto/GetReviewCardsResponseDto.java
@@ -24,7 +24,7 @@ public class GetReviewCardsResponseDto {
     private boolean hasPrevious;
     private long totalElements;
 
-    public static GetReviewCardsResponseDto from(Page<Review> reviews, Member member) {
+    public static GetReviewCardsResponseDto from(Page<Review> reviews, Member member, String profileImageUrl) {
 
         List<ReviewCardResponseDto> reviewCardResponseDtoList
                 = reviews.getContent().stream()
@@ -32,7 +32,7 @@ public class GetReviewCardsResponseDto {
                         review -> ReviewCardResponseDto.from(
                                 BookDto.from(review.getBook(), member),
                                 ReviewDto.from(review, member),
-                                MemberProfileDto.from(review.getMember())
+                                MemberProfileDto.from(review.getMember(), profileImageUrl)
                         )
                 ).toList();
 

--- a/api/src/main/java/com/example/muse/domain/review/dto/GetReviewCardsResponseDto.java
+++ b/api/src/main/java/com/example/muse/domain/review/dto/GetReviewCardsResponseDto.java
@@ -11,6 +11,8 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 @Getter
 @NoArgsConstructor
@@ -36,6 +38,30 @@ public class GetReviewCardsResponseDto {
                         )
                 ).toList();
 
+
+        return GetReviewCardsResponseDto.builder()
+                .reviews(reviewCardResponseDtoList)
+                .page(reviews.getNumber() + 1)
+                .totalPages(reviews.getTotalPages())
+                .hasNext(reviews.hasNext())
+                .hasPrevious(reviews.hasPrevious())
+                .totalElements(reviews.getTotalElements())
+                .build();
+    }
+
+    public static GetReviewCardsResponseDto from(Page<Review> reviews, Member member, Map<UUID, String> profileImageMap) {
+
+        List<ReviewCardResponseDto> reviewCardResponseDtoList = reviews.getContent().stream()
+                .map(review -> {
+                    String profileImageUrl = profileImageMap.get(review.getMember().getId());
+
+                    return ReviewCardResponseDto.from(
+                            BookDto.from(review.getBook(), member),
+                            ReviewDto.from(review, member),
+                            MemberProfileDto.from(review.getMember(), profileImageUrl)
+                    );
+                })
+                .toList();
 
         return GetReviewCardsResponseDto.builder()
                 .reviews(reviewCardResponseDtoList)

--- a/api/src/main/java/com/example/muse/domain/review/dto/ReviewDto.java
+++ b/api/src/main/java/com/example/muse/domain/review/dto/ReviewDto.java
@@ -1,5 +1,6 @@
 package com.example.muse.domain.review.dto;
 
+import com.example.muse.domain.like.Likes;
 import com.example.muse.domain.member.Member;
 import com.example.muse.domain.review.Review;
 import lombok.AllArgsConstructor;
@@ -20,8 +21,25 @@ public class ReviewDto {
 
     public static ReviewDto from(Review review, Member member) {
 
+        Likes likes = Likes.builder()
+                .member(member)
+                .review(review)
+                .build();
+
         boolean isLiked = member != null &&
-                review.getLikes().stream().anyMatch(like -> like.getMember().getId().equals(member.getId()));
+                review.getLikes().contains(likes);
+
+        return ReviewDto.builder()
+                .id(review.getId())
+                .content(review.getContent())
+                .imageUrl(review.getImage() != null ? review.getImage().getImageUrl() : null)
+                .likeCount(review.getLikes().size())
+                .isLike(isLiked)
+                .build();
+    }
+
+    public static ReviewDto from(Review review, Member member, boolean isLiked) {
+
 
         return ReviewDto.builder()
                 .id(review.getId())

--- a/api/src/main/java/com/example/muse/global/security/config/SecurityPathConfig.java
+++ b/api/src/main/java/com/example/muse/global/security/config/SecurityPathConfig.java
@@ -15,7 +15,7 @@ public class SecurityPathConfig {
             "/api/books/*/reviews/*",
             "/api/reviews",
             "/api/users/*/reviews",
-            "/profiles/*"
-
+            "/api/users/*/books",
+            "/api/profiles/*"
     };
 }

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -18,7 +18,7 @@ logging.level.org.springframework.security=error
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.highlight_sql=true
 
-spring.jpa.properties.hibernate.default_batch_fetch_size=10
+spring.jpa.properties.hibernate.default_batch_fetch_size=50
 
 spring.jackson.time-zone=Asia/Seoul
 spring.jpa.properties.hibernate.jdbc.time_zone=Asia/Seoul

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -12,11 +12,13 @@ spring.docker.compose.lifecycle-management=start-and-stop
 spring.docker.compose.enabled=true
 
 spring.jpa.show-sql=true
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=validate
 
 logging.level.org.springframework.security=error
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.highlight_sql=true
+
+spring.jpa.properties.hibernate.default_batch_fetch_size=10
 
 spring.jackson.time-zone=Asia/Seoul
 spring.jpa.properties.hibernate.jdbc.time_zone=Asia/Seoul


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **기능 개선**
	- 이미지와 리뷰 간의 관계가 일대다에서 일대일로 변경되었습니다. 이제 각 이미지는 하나의 리뷰만 가질 수 있습니다.
	- 리뷰와 이미지 간의 연결이 일대일로 변경되어, 리뷰 삭제 시 연관된 이미지도 자동으로 삭제됩니다.
	- 리뷰 목록과 사용자 프로필에 프로필 이미지 URL이 포함되어 더욱 풍부한 정보를 제공합니다.
	- 사용자 프로필에서 리뷰 수가 새롭게 표시됩니다.
	- 리뷰, 도서, 회원 관련 데이터 조회 시 연관된 엔티티를 효율적으로 가져오도록 개선되었습니다.

- **기능 변경**
	- 이미지 조회 관련 일부 메서드가 제거되었습니다.
	- 좋아요 관련 객체의 동등성 비교 방식이 변경되어 일관성 있는 처리와 성능 향상이 기대됩니다.
	- 보안 설정에서 공개 접근 가능한 URL 패턴이 일부 조정되었습니다.

- **성능 개선**
	- 데이터베이스 쿼리가 JPQL과 엔티티 그래프를 활용하도록 변경되어 쿼리 효율성과 유지보수성이 향상되었습니다.
	- 배치 페치 크기 설정이 추가되어 데이터 조회 시 성능 최적화가 이루어졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->