### PR TITLE
fix: BookDetail fetch

### DIFF
--- a/client/src/pages/BookDetail.jsx
+++ b/client/src/pages/BookDetail.jsx
@@ -64,11 +64,20 @@ export default function BookDetail() {
   };
 
   useEffect(() => {
+    setReviews([]);
+    setPage({
+      pageNo: 1,
+      totalPages: 1,
+      totalElements: 0,
+      hasPrevious: false,
+      hasNext: false,
+    });
     const fetchData = async () => {
       const response = await bookApi.getBook(bookId);
       setBookInfo(response.data.data);
     };
     fetchData();
+    
   }, [bookId]);
 
   const sortListHandler = (selected) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 도서 상세 페이지에서 다른 도서로 이동 시 리뷰 목록과 페이지네이션 상태가 올바르게 초기화되어 이전 도서의 리뷰 정보가 남아있지 않도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->